### PR TITLE
Fix docker build symlink error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,4 +3,14 @@
 .idea
 .vscode
 tmp*
+.git
+*.log
+node_modules
+__pycache__
+*.pyc
+.pytest_cache
+dbm-services/
+docs/
+helm-charts/
+*.md
 


### PR DESCRIPTION
Update `.dockerignore` to exclude more unnecessary files and directories.

This optimizes the Docker build context, reduces image size, and helps resolve `symlink` errors during Docker builds by reducing the amount of data Docker needs to process.

---
<a href="https://cursor.com/background-agent?bcId=bc-90cb7ede-9818-4c2b-9d06-0e356ac66582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90cb7ede-9818-4c2b-9d06-0e356ac66582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

