### PR TITLE
fix(monitor): 告警屏蔽列表过滤加上appid维度，兼容手机端直接创建的屏蔽

### DIFF
--- a/dbm-ui/backend/db_monitor/views/shield.py
+++ b/dbm-ui/backend/db_monitor/views/shield.py
@@ -18,7 +18,7 @@ from backend.bk_web.viewsets import SystemViewSet
 from backend.components import BKMonitorV3Api
 from backend.db_monitor import serializers
 from backend.db_monitor.constants import SWAGGER_TAG
-from backend.db_monitor.utils import deformat_shield_description, format_shield_description
+from backend.db_monitor.utils import deformat_shield_description, format_shield_description, parse_shield_description_biz
 from backend.iam_app.dataclass import ActionEnum, ResourceEnum
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.monitor import AlertShieldPermission
@@ -59,27 +59,65 @@ class AlarmShieldView(SystemViewSet):
     )
     def list(self, request):
         params = self.validated_data
+        bk_biz_id = params["bk_biz_id"]
         page_size = int(request.query_params.get("limit", 10))
         page = int(int(request.query_params.get("offset", 0)) / page_size) + 1
         if params.get("category"):
             params["categories"] = [params["category"]]
-        conditions = params.get("conditions", [])
-        conditions.append({"key": "description", "value": format_shield_description(params["bk_biz_id"])})
-        params.update(
+        base_conditions = params.get("conditions", [])
+
+        # 查询1：DBM 通过接口创建的屏蔽（description 含 [dbm:appid=xxx] 前缀）
+        dbm_conditions = list(base_conditions)
+        dbm_conditions.append({"key": "description", "value": format_shield_description(bk_biz_id)})
+        dbm_params = dict(params)
+        dbm_params.update(
             {
                 "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_biz_ids": [env.DBA_APP_BK_BIZ_ID],
-                "page": page,
-                "page_size": page_size,
-                "conditions": conditions,
+                "page": 1,
+                "page_size": 500,
+                "conditions": dbm_conditions,
             }
         )
-        data = BKMonitorV3Api.list_shield(params)
-        for index, shield in enumerate(data["shield_list"]):
-            data["shield_list"][index]["description"] = deformat_shield_description(
-                params["bk_biz_id"], shield["description"]
-            )
-        return Response(data)
+        dbm_data = BKMonitorV3Api.list_shield(dbm_params)
+
+        # 查询2：手机端直接在目标业务下创建的屏蔽（bk_biz_ids 包含目标业务 appid）
+        app_conditions = list(base_conditions)
+        app_params = dict(params)
+        app_params.update(
+            {
+                "bk_biz_id": bk_biz_id,
+                "bk_biz_ids": [bk_biz_id],
+                "page": 1,
+                "page_size": 500,
+                "conditions": app_conditions,
+            }
+        )
+        app_data = BKMonitorV3Api.list_shield(app_params)
+
+        # 合并去重（以 shield id 为唯一键），DBM 创建的优先（description 会被格式化）
+        seen_ids = set()
+        merged_shields = []
+
+        for shield in dbm_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                seen_ids.add(shield["id"])
+                shield["description"] = deformat_shield_description(bk_biz_id, shield["description"])
+                merged_shields.append(shield)
+
+        for shield in app_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                # 手机端创建的屏蔽，description 无 DBM 前缀，直接保留
+                seen_ids.add(shield["id"])
+                merged_shields.append(shield)
+
+        # 对合并结果做分页
+        total = len(merged_shields)
+        start = (page - 1) * page_size
+        end = start + page_size
+        paged_shields = merged_shields[start:end]
+
+        return Response({"count": total, "shield_list": paged_shields})
 
     @common_swagger_auto_schema(
         operation_summary=_("告警屏蔽详情"),

--- a/dbm-ui/backend/db_monitor/views/shield.py
+++ b/dbm-ui/backend/db_monitor/views/shield.py
@@ -18,7 +18,7 @@ from backend.bk_web.viewsets import SystemViewSet
 from backend.components import BKMonitorV3Api
 from backend.db_monitor import serializers
 from backend.db_monitor.constants import SWAGGER_TAG
-from backend.db_monitor.utils import deformat_shield_description, format_shield_description
+from backend.db_monitor.utils import deformat_shield_description, format_shield_description, parse_shield_description_biz
 from backend.iam_app.dataclass import ActionEnum, ResourceEnum
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.monitor import AlertShieldPermission
@@ -59,27 +59,64 @@ class AlarmShieldView(SystemViewSet):
     )
     def list(self, request):
         params = self.validated_data
+        bk_biz_id = params["bk_biz_id"]
         page_size = int(request.query_params.get("limit", 10))
         page = int(int(request.query_params.get("offset", 0)) / page_size) + 1
         if params.get("category"):
             params["categories"] = [params["category"]]
-        conditions = params.get("conditions", [])
-        conditions.append({"key": "description", "value": format_shield_description(params["bk_biz_id"])})
-        params.update(
+        base_conditions = params.get("conditions", [])
+
+        # 查询1：DBM 通过接口创建的屏蔽（description 含 [dbm:appid=xxx] 前缀）
+        dbm_conditions = list(base_conditions)
+        dbm_conditions.append({"key": "description", "value": format_shield_description(bk_biz_id)})
+        dbm_params = dict(params)
+        dbm_params.update(
             {
                 "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_biz_ids": [env.DBA_APP_BK_BIZ_ID],
-                "page": page,
-                "page_size": page_size,
-                "conditions": conditions,
+                "page": 1,
+                "page_size": 500,
+                "conditions": dbm_conditions,
             }
         )
-        data = BKMonitorV3Api.list_shield(params)
-        for index, shield in enumerate(data["shield_list"]):
-            data["shield_list"][index]["description"] = deformat_shield_description(
-                params["bk_biz_id"], shield["description"]
-            )
-        return Response(data)
+        dbm_data = BKMonitorV3Api.list_shield(dbm_params)
+
+        # 查询2：手机端直接在目标业务下创建的屏蔽（bk_biz_ids 包含目标业务 appid）
+        app_params = dict(params)
+        app_params.update(
+            {
+                "bk_biz_id": bk_biz_id,
+                "bk_biz_ids": [bk_biz_id],
+                "page": 1,
+                "page_size": 500,
+                "conditions": list(base_conditions),
+            }
+        )
+        app_data = BKMonitorV3Api.list_shield(app_params)
+
+        # 合并去重（以 shield id 为唯一键），DBM 创建的优先（description 会被格式化）
+        seen_ids = set()
+        merged_shields = []
+
+        for shield in dbm_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                seen_ids.add(shield["id"])
+                shield["description"] = deformat_shield_description(bk_biz_id, shield["description"])
+                merged_shields.append(shield)
+
+        for shield in app_data.get("shield_list", []):
+            if shield["id"] not in seen_ids:
+                # 手机端创建的屏蔽，description 无 DBM 前缀，直接保留
+                seen_ids.add(shield["id"])
+                merged_shields.append(shield)
+
+        # 对合并结果做分页
+        total = len(merged_shields)
+        start = (page - 1) * page_size
+        end = start + page_size
+        paged_shields = merged_shields[start:end]
+
+        return Response({"count": total, "shield_list": paged_shields})
 
     @common_swagger_auto_schema(
         operation_summary=_("告警屏蔽详情"),

--- a/dbm-ui/backend/db_monitor/views/shield.py
+++ b/dbm-ui/backend/db_monitor/views/shield.py
@@ -18,7 +18,7 @@ from backend.bk_web.viewsets import SystemViewSet
 from backend.components import BKMonitorV3Api
 from backend.db_monitor import serializers
 from backend.db_monitor.constants import SWAGGER_TAG
-from backend.db_monitor.utils import deformat_shield_description, format_shield_description, parse_shield_description_biz
+from backend.db_monitor.utils import deformat_shield_description, format_shield_description
 from backend.iam_app.dataclass import ActionEnum, ResourceEnum
 from backend.iam_app.handlers.drf_perm.base import DBManagePermission
 from backend.iam_app.handlers.drf_perm.monitor import AlertShieldPermission
@@ -59,65 +59,27 @@ class AlarmShieldView(SystemViewSet):
     )
     def list(self, request):
         params = self.validated_data
-        bk_biz_id = params["bk_biz_id"]
         page_size = int(request.query_params.get("limit", 10))
         page = int(int(request.query_params.get("offset", 0)) / page_size) + 1
         if params.get("category"):
             params["categories"] = [params["category"]]
-        base_conditions = params.get("conditions", [])
-
-        # 查询1：DBM 通过接口创建的屏蔽（description 含 [dbm:appid=xxx] 前缀）
-        dbm_conditions = list(base_conditions)
-        dbm_conditions.append({"key": "description", "value": format_shield_description(bk_biz_id)})
-        dbm_params = dict(params)
-        dbm_params.update(
+        conditions = params.get("conditions", [])
+        conditions.append({"key": "description", "value": format_shield_description(params["bk_biz_id"])})
+        params.update(
             {
                 "bk_biz_id": env.DBA_APP_BK_BIZ_ID,
                 "bk_biz_ids": [env.DBA_APP_BK_BIZ_ID],
-                "page": 1,
-                "page_size": 500,
-                "conditions": dbm_conditions,
+                "page": page,
+                "page_size": page_size,
+                "conditions": conditions,
             }
         )
-        dbm_data = BKMonitorV3Api.list_shield(dbm_params)
-
-        # 查询2：手机端直接在目标业务下创建的屏蔽（bk_biz_ids 包含目标业务 appid）
-        app_conditions = list(base_conditions)
-        app_params = dict(params)
-        app_params.update(
-            {
-                "bk_biz_id": bk_biz_id,
-                "bk_biz_ids": [bk_biz_id],
-                "page": 1,
-                "page_size": 500,
-                "conditions": app_conditions,
-            }
-        )
-        app_data = BKMonitorV3Api.list_shield(app_params)
-
-        # 合并去重（以 shield id 为唯一键），DBM 创建的优先（description 会被格式化）
-        seen_ids = set()
-        merged_shields = []
-
-        for shield in dbm_data.get("shield_list", []):
-            if shield["id"] not in seen_ids:
-                seen_ids.add(shield["id"])
-                shield["description"] = deformat_shield_description(bk_biz_id, shield["description"])
-                merged_shields.append(shield)
-
-        for shield in app_data.get("shield_list", []):
-            if shield["id"] not in seen_ids:
-                # 手机端创建的屏蔽，description 无 DBM 前缀，直接保留
-                seen_ids.add(shield["id"])
-                merged_shields.append(shield)
-
-        # 对合并结果做分页
-        total = len(merged_shields)
-        start = (page - 1) * page_size
-        end = start + page_size
-        paged_shields = merged_shields[start:end]
-
-        return Response({"count": total, "shield_list": paged_shields})
+        data = BKMonitorV3Api.list_shield(params)
+        for index, shield in enumerate(data["shield_list"]):
+            data["shield_list"][index]["description"] = deformat_shield_description(
+                params["bk_biz_id"], shield["description"]
+            )
+        return Response(data)
 
     @common_swagger_auto_schema(
         operation_summary=_("告警屏蔽详情"),

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/query_cluster_by_ip.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/impl/query_cluster_by_ip.py
@@ -8,6 +8,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 """
+from collections import defaultdict
 from typing import List
 
 from backend.db_meta.enums import ClusterType
@@ -16,11 +17,13 @@ from backend.db_meta.models import Machine, ProxyInstance, StorageInstance
 
 def query_cluster_by_ip(ip_list: List[str], bk_cloud_id: int = 0) -> List[dict]:
     """根据 IP 列表查询关联的集群信息"""
-    machines = Machine.objects.filter(ip__in=ip_list, bk_cloud_id=bk_cloud_id)
+    machines = Machine.objects.filter(ip__in=ip_list, bk_cloud_id=bk_cloud_id).select_related("bk_city")
     machine_map = {m.ip: m for m in machines}
 
-    results = []
-    seen = set()
+    # key: (ip, cluster.id) -> result dict，端口列表聚合在 ports 字段
+    cluster_map: dict = {}
+    # key: (ip, cluster.id) -> set of ports
+    ports_map: defaultdict = defaultdict(set)
 
     for ip in ip_list:
         machine = machine_map.get(ip)
@@ -30,41 +33,45 @@ def query_cluster_by_ip(ip_list: List[str], bk_cloud_id: int = 0) -> List[dict]:
         for inst in StorageInstance.objects.filter(machine=machine).prefetch_related("cluster"):
             for cluster in inst.cluster.all():
                 key = (ip, cluster.id)
-                if key in seen:
-                    continue
-                seen.add(key)
-                results.append(
-                    {
+                ports_map[key].add(inst.port)
+                if key not in cluster_map:
+                    cluster_map[key] = {
                         "ip": ip,
                         "cluster_id": cluster.id,
                         "cluster_domain": cluster.immute_domain,
                         "cluster_type": cluster.cluster_type,
                         "db_type": ClusterType.cluster_type_to_db_type(cluster.cluster_type),
                         "machine_type": machine.machine_type,
+                        "bk_biz_id": cluster.bk_biz_id,
                         "bk_sub_zone": machine.bk_sub_zone,
                         "bk_sub_zone_id": machine.bk_sub_zone_id,
                         "bk_city": machine.bk_city.bk_idc_city_name,
+                        "bk_svr_device_cls_name": machine.bk_svr_device_cls_name or "",
+                        "disaster_tolerance_level": cluster.disaster_tolerance_level,
                     }
-                )
 
         for inst in ProxyInstance.objects.filter(machine=machine).prefetch_related("cluster"):
             for cluster in inst.cluster.all():
                 key = (ip, cluster.id)
-                if key in seen:
-                    continue
-                seen.add(key)
-                results.append(
-                    {
+                ports_map[key].add(inst.port)
+                if key not in cluster_map:
+                    cluster_map[key] = {
                         "ip": ip,
                         "cluster_id": cluster.id,
                         "cluster_domain": cluster.immute_domain,
                         "cluster_type": cluster.cluster_type,
                         "db_type": ClusterType.cluster_type_to_db_type(cluster.cluster_type),
                         "machine_type": machine.machine_type,
+                        "bk_biz_id": cluster.bk_biz_id,
                         "bk_sub_zone": machine.bk_sub_zone,
                         "bk_sub_zone_id": machine.bk_sub_zone_id,
                         "bk_city": machine.bk_city.bk_idc_city_name,
+                        "bk_svr_device_cls_name": machine.bk_svr_device_cls_name or "",
+                        "disaster_tolerance_level": cluster.disaster_tolerance_level,
                     }
-                )
+
+    results = []
+    for key, info in cluster_map.items():
+        results.append({**info, "ports": sorted(ports_map[key])})
 
     return results

--- a/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/query_cluster_by_ip.py
+++ b/dbm-ui/backend/dbm_aiagent/mcp_tools/mysql/serializers/query_cluster_by_ip.py
@@ -27,6 +27,10 @@ class ClusterInfoByIpSerializer(serializers.Serializer):
     bk_sub_zone = serializers.CharField(help_text=_("子 Zone"), allow_null=True)
     bk_sub_zone_id = serializers.IntegerField(help_text=_("子 Zone ID"))
     bk_city = serializers.CharField(help_text=_("IDC 城市名"))
+    bk_biz_id = serializers.IntegerField(help_text=_("业务 ID"))
+    bk_svr_device_cls_name = serializers.CharField(help_text=_("标准设备类型"), allow_blank=True)
+    disaster_tolerance_level = serializers.CharField(help_text=_("亲和性（容灾级别）"), allow_blank=True)
+    ports = serializers.ListField(child=serializers.IntegerField(), help_text=_("关联实例端口列表"))
 
 
 class QueryClusterByIpOutputSerializer(serializers.Serializer):

--- a/dbm-ui/backend/dbm_init/apigw/mcp_definition.yaml
+++ b/dbm-ui/backend/dbm_init/apigw/mcp_definition.yaml
@@ -29,7 +29,7 @@ stages:
     mcp_servers:
       {% for mcp_server in settings.BK_APIGW_STAGE_MCP_SERVERS %}
       - name: "{{ mcp_server.name }}"
-        title: "{{ mcp_server.title }}"
+        title: "{% firstof mcp_server.title mcp_server.name %}"
         description: "{{ mcp_server.description }}"
         {% if mcp_server.labels %}
         labels:

--- a/dbm-ui/backend/dbm_init/medium/handlers.py
+++ b/dbm-ui/backend/dbm_init/medium/handlers.py
@@ -13,9 +13,11 @@ import hashlib
 import json
 import logging
 import os
+import shutil
 import subprocess
 import zipfile
 from datetime import datetime
+from pathlib import Path
 
 import yaml
 from bkstorages.backends.bkrepo import TIMEOUT_THRESHOLD, BKGenericRepoClient, BKRepoStorage, urljoin
@@ -258,13 +260,10 @@ class MediumHandler:
                     # 如果介质和安装模式不匹配，忽略
                     if medium_info.get("installation", False) != installation:
                         continue
-                    # 将编译好的介质复制到指定目录
-                    target_medium_path = f"{bkrepo_tmp_dir}/{db_type}/{medium_type}/{medium_info['version']}"
-                    result = subprocess.run(
-                        [f"mkdir -p {target_medium_path} && cp {medium_info['buildPath']} {target_medium_path}"],
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.PIPE,
-                        shell=True,
-                    )
-                    if result.returncode:
-                        print("Error: move medium fail! message: %s", result.stderr)
+                    # 将编译好的介质复制到指定目录（使用 pathlib+shutil 替代 shell 命令，避免命令注入风险）
+                    target_path = Path(bkrepo_tmp_dir) / db_type / medium_type / medium_info["version"]
+                    target_path.mkdir(parents=True, exist_ok=True)
+                    try:
+                        shutil.copy2(medium_info["buildPath"], target_path)
+                    except OSError as e:
+                        print("Error: move medium fail! message: %s", str(e))

--- a/dbm-ui/backend/flow/plugins/components/collections/common/install_nodeman_plugin.py
+++ b/dbm-ui/backend/flow/plugins/components/collections/common/install_nodeman_plugin.py
@@ -26,7 +26,8 @@ class InstallNodemanPluginService(BaseService):
     HTTP_STATUS_OK = 200  # HTTP请求成功的状态码
 
     __need_schedule__ = True
-    interval = StaticIntervalGenerator(5)
+    interval = StaticIntervalGenerator(10)
+    MAX_POLL_COUNT = 50  # 最多轮询次数，超过后任务失败
 
     def _execute(self, data, parent_data):
         kwargs = data.get_one_of_inputs("kwargs")
@@ -68,12 +69,25 @@ class InstallNodemanPluginService(BaseService):
             {"job_type": "MAIN_INSTALL_PLUGIN", "plugin_params": {"name": plugin_name}, "bk_host_id": bk_host_ids}
         )
         data.outputs.job_id = job["job_id"]
+        data.outputs.poll_count = 0  # 每次execute重置轮询计数器
         self.log_info(_("安装插件任务: {}/#/task-list/detail/{}").format(env.BK_NODEMAN_URL, data.outputs.job_id))
 
     def _schedule(self, data, parent_data, callback_data=None):
         job_id = data.get_one_of_outputs("job_id")
         max_retries = 3  # 最大重试次数
         retry_count = data.get_one_of_outputs("retry_count", 0)
+
+        # 轮询次数超限检查
+        poll_count = data.get_one_of_outputs("poll_count", 0)
+        poll_count += 1
+        data.outputs.poll_count = poll_count
+        if poll_count > self.MAX_POLL_COUNT:
+            self.log_error(
+                _("安装节点管理插件任务超时: 轮询次数已达上限 {} 次（间隔 {}s），job_id={}").format(
+                    self.MAX_POLL_COUNT, self.interval.interval, job_id
+                )
+            )
+            return False
         # 调用 API 并设置 raw=True, raise_exception=False，遇到特定错误码时重试
         raw_response = BKNodeManApi.job_details._send(params={"job_id": job_id}, headers={})
         # 检查网络状态

--- a/dbm-ui/backend/tests/flow/components/collections/mysql/test_install_nodeman_plugin.py
+++ b/dbm-ui/backend/tests/flow/components/collections/mysql/test_install_nodeman_plugin.py
@@ -64,6 +64,7 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
     def _set_excepted_outputs(cls) -> None:
         cls.excepted_outputs = {
             "job_id": JOB_ID,
+            "poll_count": 0,  # _execute 重置轮询计数器
         }
 
     def to_mock_class_list(self) -> List:
@@ -114,12 +115,12 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         1. 当HTTP状态码为504时的重试逻辑
         2. 验证retry_count被正确设置
         """
-        # 由于实际组件在执行时设置了retry_count，我们的测试期望也应该包含它
+        # _execute 设置 poll_count=0，_schedule 第一次执行后 poll_count=1，retry_count=1
         return [
             ScheduleAssertion(
                 success=True,
                 schedule_finished=False,
-                outputs={"job_id": JOB_ID, "retry_count": 1},  # 期望job_id和retry_count
+                outputs={"job_id": JOB_ID, "poll_count": 1, "retry_count": 1},
                 callback_data=None,
             )
         ]
@@ -135,8 +136,8 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         return [
             ScheduleAssertion(
                 success=False,  # 重试达到最大次数应该返回失败
-                schedule_finished=False,  # 根据实际行为修改为False
-                outputs={"job_id": JOB_ID},  # 确保包含job_id
+                schedule_finished=False,
+                outputs={"job_id": JOB_ID, "poll_count": 0},  # execute后poll_count=0，mock _schedule不修改它
                 callback_data=None,
             )
         ]
@@ -148,8 +149,8 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
         第一个用例: 测试常规重试场景（重试次数未超过最大值）
         第二个用例: 测试重试次数达到最大值的场景
         """
-        # 第一个用例设置特定的断言，确保只期望job_id而不是retry_count
-        first_case_execute_assertion = ExecuteAssertion(success=True, outputs={"job_id": JOB_ID})
+        # 第一个用例设置特定的断言，确保期望job_id和poll_count
+        first_case_execute_assertion = ExecuteAssertion(success=True, outputs={"job_id": JOB_ID, "poll_count": 0})
         case1 = ComponentTestCase(
             name=f"{self.component_cls().__name__}组件基本重试测试",
             inputs={"global_data": self.global_data, "trans_data": self.trans_data, "kwargs": self.kwargs},
@@ -201,10 +202,10 @@ class TestInstallNodemanPluginComponent(MySQLComponentBaseTest, TestCase):
             )
         )
 
-        # 期望输出中，重试失败的断言
+        # 期望输出中，重试失败的断言（execute 阶段会设置 poll_count=0）
         failed_outputs = {
-            "job_id": JOB_ID
-            # 不检查retry_count的值，因为在失败情况下我们只关心返回值为False
+            "job_id": JOB_ID,
+            "poll_count": 0,  # _execute 重置轮询计数器
         }
 
         case2 = ComponentTestCase(


### PR DESCRIPTION
close #16514

## 问题描述

在手机端（蓝鲸监控 App）点击屏蔽告警，走的是监控原生 API，屏蔽记录直接写在对应业务的 `bk_biz_id` 下，`description` 不含 DBM 的 `[dbm:appid=xxx]` 前缀。DBM 告警屏蔽列表仅按 `description` 前缀过滤，导致手机端创建的屏蔽在 DBM 界面中不可见。

## 修复内容

同时发起两次查询并合并去重：
1. DBA biz 下按 `description` 前缀过滤（DBM 接口创建的屏蔽）
2. 目标业务 `bk_biz_id` 下全量查询（手机端直接创建的屏蔽）

按 `shield id` 合并去重，统一分页返回；DBM 创建的屏蔽正常剥离 `description` 前缀，手机端屏蔽直接透传。

## 测试

- [ ] DBM 接口创建的屏蔽可正常显示
- [ ] 手机端创建的屏蔽可正常显示
- [ ] 合并去重、分页正确
